### PR TITLE
Added URL shortening and OHIF data source switching to Orthanc Auth Service

### DIFF
--- a/sources/orthanc_auth_service/shares/exceptions.py
+++ b/sources/orthanc_auth_service/shares/exceptions.py
@@ -15,3 +15,11 @@ class InvalidTokenException(SharesException):
 
     def __init__(self):
         super().__init__(msg="Invalid token")
+
+
+class ShlinkException(Exception):
+    def __init__(self, msg="Error related to Shlink (URL Shortener)"):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg

--- a/sources/orthanc_auth_service/shares/shlink.py
+++ b/sources/orthanc_auth_service/shares/shlink.py
@@ -1,0 +1,66 @@
+import httpx
+import logging
+from dataclasses import dataclass, asdict, field
+from typing import Optional, List, Dict
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO)
+
+SHLINK_URL_ENDPOINT = "/rest/v3/short-urls"
+
+@dataclass
+class ShortenURLParameters:
+    longUrl: str
+    deviceLongUrls: Optional[Dict[str, str]] = None
+    validSince: Optional[datetime] = None
+    validUntil: Optional[datetime] = None
+    maxVisits: Optional[int] = None
+    tags: List[str] = field(default_factory=list)
+    title: Optional[str] = None
+    crawlable: Optional[bool] = None
+    forwardQuery: Optional[bool] = None
+    customSlug: Optional[str] = None
+    findIfExists: Optional[bool] = None
+    domain: Optional[str] = None
+    shortCodeLength: Optional[int] = None
+
+class Shlink:
+    def __init__(self, base_url: str, api_key: str):
+        self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
+        self.headers = {
+            "X-Api-Key": self.api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
+
+    def shorten_url(self, params: ShortenURLParameters) -> Optional[str]:
+        """Shorten a given URL using Shlink. Return the shortened URL or None if there is an error."""
+        endpoint_url = f"{self.base_url}{SHLINK_URL_ENDPOINT}"
+        payload = asdict(params)
+        if payload.get('validSince'):
+            payload['validSince'] = payload['validSince'].isoformat()
+        if payload.get('validUntil'):
+            payload['validUntil'] = payload['validUntil'].isoformat()
+
+        # Remove fields with None values from the payload
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            response = httpx.post(endpoint_url, headers=self.headers, json=payload, timeout=10)
+
+            if not response.is_error:
+                data = response.json()
+                short_code = data.get("shortCode")
+                if short_code:
+                    return f"{self.base_url}/{short_code}"
+                logging.error(f"Shlink response does not contain a shortCode: {response.text}")
+            else:
+                logging.error(f"Error shortening URL with Shlink. Status Code: {response.status_code}. Response: {response.text}")
+
+        except httpx.RequestError as exc:
+            logging.error(f"Request error encountered while shortening URL with Shlink: {exc}")
+        except Exception as exc:
+            logging.error(f"Unexpected error while shortening URL with Shlink: {exc}")
+
+        return None


### PR DESCRIPTION
Hello everyone,

These changes will add an ability to connect to a self-hosted URL shortener service (Shlink) which will shorten links meant for publication.

to get URL shortening to work you need to:

1) Run shlink in a separate container and set up DNS resolution and routing for it.
2) Run 'shlink generate:api-key' inside shlink container
set following env vars for auth service:
SHLINK_ENABLED=true
SHLINK_BASE_URL=https://your.domain.com/
SHLINK_API_KEY=xxxx-xxx-xxx

Landing page links will now be shortened to something like https://your.domain.com/xYY4x

Additionally, I've added an OHIF_DATA_SOURCE env var which will default to dicom-json and accepts dicom-web.
This is to make auth service compatible with the new OHIF plugin.

Please review and merge.



