### PR TITLE
Fix wrong RetrieveURL in DICOMweb queries

### DIFF
--- a/minimal-setup/basic-auth/docker-compose.yml
+++ b/minimal-setup/basic-auth/docker-compose.yml
@@ -59,6 +59,9 @@ services:
             "WebServiceUsername": "share-user",
             "WebServicePassword": "change-me"
             //"CheckedLevel": "studies"
+          },
+          "DicomWeb": {
+            "PublicRoot": "/orthanc/dicom-web"
           }
         
         }


### PR DESCRIPTION
Without configuring the PublicRoot, DICOMweb responses contain the wrong RetrieveURL:

```
$ curl http://localhost/orthanc/dicom-web/studies/1.3.46.670589.10.900123.19970114.35056000060.1/series/1.3.46.670589.10.900123.19970114.35056000060.3/instances -u admin | jq '.[0]."00081190"'                                                        
Enter host password for user 'admin':
{
  "Value": [
    "http://localhost/dicom-web/studies/1.3.46.670589.10.900123.19970114.35056000060.1/series/1.3.46.670589.10.900123.19970114.35056000060.3/instances/1.3.46.670589.10.900123.19970114.35100000070"
  ],
  "vr": "UR"
}
```
Note that the DICOMweb endpoint is localhost/**orthanc**/dicom-web, but the RetrieveURL just localhost/dicom-web.