### PR TITLE
Pass user_id in UserProfileResponse when using Keycloak API key

### DIFF
--- a/sources/orthanc_auth_service/shares/keycloak_admin.py
+++ b/sources/orthanc_auth_service/shares/keycloak_admin.py
@@ -48,6 +48,7 @@ class KeycloakAdmin:
             user = keycloak_user_response.json()
             return UserProfileResponse(
                     name=user['username'],
+                    user_id=user['id'],
                     permissions=[],
                     validity=60,
                     authorized_labels=[]
@@ -102,6 +103,7 @@ class KeycloakAdmin:
 
                 return UserProfileResponse(
                     name=user['username'],
+                    user_id=user['id'],
                     permissions=profile_from_config.permissions,
                     validity=60,
                     authorized_labels=profile_from_config.authorized_labels


### PR DESCRIPTION
Ran into a permissions issue when writing a label, when using the API key in a Orthanc with Keycloak environment with auth plugin enabled and audit logging turned on:

` curl -v -X PUT -d "" \
    -H "api-key: YOUR_API_KEY" \
    http://orthanc:8042/studies/f32af386-a805b002-f0cb50c5-2230f878-ceb8b5ce/labels/MY_LABEL`

response:
```
"Details" : "Auth plugin: no user profile or UserData found, unable to delete/put label with audit logs enabled.",
"HttpError" : "Forbidden",
"HttpStatus" : 403,
"Message" : "Access to a resource is forbidden",
"Method" : "PUT",
"OrthancError" : "Access to a resource is forbidden",
"OrthancStatus" : 45,
"Uri" : "/studies/f32af386-a805b002-f0cb50c5-2230f878-ceb8b5ce/labels/MY_LABEL"
```

This appeared to happen because the user_id was not passed as part of the response so the auth plugin couldn't figure out who the user was that the API key belonged to. Problem did not appear in the browser with the JWT route.